### PR TITLE
Update dfrobot_i2c_rgbbutton.cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ External component for ESPHome supporting the [DFRobot I2C RGB Button](https://w
 # Compatibility
 
 I have tested the code on ESP32, it works fine.
+Works with both Arduino and ESP-IDF 
 
 # Functionality
 

--- a/components/dfrobot_i2c_rgbbutton/dfrobot_i2c_rgbbutton.cpp
+++ b/components/dfrobot_i2c_rgbbutton/dfrobot_i2c_rgbbutton.cpp
@@ -65,9 +65,10 @@ void DFRobot_i2c_RGBButton::set_button_color(uint8_t r, uint8_t g, uint8_t b, bo
 void DFRobot_i2c_RGBButton::set_button_color(unsigned long color, bool force) {
   // convert hex to RGB
   uint8_t rgbBuf[3] = {
-      (color >> 16) & 0xFF,
-      (color >> 8) & 0xFF,
-      color & 0xFF
+      static_cast<uint8_t>((color >> 16) & 0xFF),
+      static_cast<uint8_t>((color >> 8) & 0xFF),
+      static_cast<uint8_t>(color & 0xFF)
+
   };
 
   set_button_color(rgbBuf[0], rgbBuf[1], rgbBuf[2], force);
@@ -76,9 +77,10 @@ void DFRobot_i2c_RGBButton::set_button_color(unsigned long color, bool force) {
 void DFRobot_i2c_RGBButton::set_button_color(DFRobot_i2c_RGBButton::eGeneralRGBValue_t color, bool force) {
   // convert hex to RGB
   uint8_t rgbBuf[3] = {
-      (color >> 16) & 0xFF,
-      (color >> 8) & 0xFF,
-      color & 0xFF
+      static_cast<uint8_t>((color >> 16) & 0xFF),
+      static_cast<uint8_t>((color >> 8) & 0xFF),
+      static_cast<uint8_t>(color & 0xFF)
+
   };
 
   set_button_color(rgbBuf[0], rgbBuf[1], rgbBuf[2], force);


### PR DESCRIPTION
attempted to fix narrowing conversion errors
I was unable to build the binary with esp-idf so, tried to see what others on the internet did when they had this error. 
I don't understand why, but it's working without errors now